### PR TITLE
Change WezTerm font to Moralerspace Radon

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -19,7 +19,7 @@ config.initial_rows = 60
 -- disable ligatures: https://wezfurlong.org/wezterm/config/font-shaping.html#advanced-font-shaping-options
 config.harfbuzz_features = {'calt=0', 'clig=0', 'liga=0'}
 
-config.font = wezterm.font('CaskaydiaCove Nerd Font Mono', {
+config.font = wezterm.font('Moralerspace Radon', {
   weight = 'Regular',
   stretch = 'Normal',
   style = 'Normal',


### PR DESCRIPTION
## Summary
- repository: https://github.com/yuru7/moralerspace
- Downloaded fonts: [Moralerspace_v0.0.4.zip](https://github.com/yuru7/moralerspace/releases/download/v0.0.4/Moralerspace_v0.0.4.zip)
- font used: Moralerspace Radon

https://github.com/yossydev/dotfiles/assets/87469023/f79a65d9-feaf-4362-8a7b-7d023d5f47b8